### PR TITLE
fix: added if statement to catch other types of route destination

### DIFF
--- a/src/cidr-functions/getOccupiedCidrBlocks.js
+++ b/src/cidr-functions/getOccupiedCidrBlocks.js
@@ -21,10 +21,10 @@ function getRoutes(routeTables) {
 
     routeTables.forEach(routeTable => {
         routeTable.Routes.forEach(route => {
-            uniqueRoutes.add(route.DestinationCidrBlock);
+            const ipv4 = route.DestinationCidrBlock;
+            if(ipv4) {uniqueRoutes.add(route.DestinationCidrBlock)};
         });
     });
-
     return Array.from(uniqueRoutes);
 }
 


### PR DESCRIPTION
This is a temporary fix to make decidr ignore anything other than an ipv4 destination cidr block. An issue has been opened to handle other destination types (https://github.com/newsuk/DeCidr/issues/8)